### PR TITLE
upgrade aws provider version to ~>6.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>5.0"
+      version = "~>6.0"
     }
   }
 }
@@ -39,6 +39,7 @@ locals {
 }
 
 resource "aws_instance" "instance" {
+  region = var.region
 
   placement_group = var.placement_group
 
@@ -95,10 +96,12 @@ resource "aws_instance" "instance" {
 }
 
 data "aws_subnet" "instance" {
-  id = var.subnet_id
+  region = var.region
+  id     = var.subnet_id
 }
 
 resource "aws_ebs_volume" "raid_array" {
+  region            = var.region
   count             = var.raid_array_size > 0 ? 10 : 0
   availability_zone = data.aws_subnet.instance.availability_zone
   size              = var.raid_array_size / 10
@@ -111,6 +114,7 @@ resource "aws_ebs_volume" "raid_array" {
 }
 
 resource "aws_volume_attachment" "raid_array" {
+  region      = var.region
   count       = length(aws_ebs_volume.raid_array.*.id)
   volume_id   = aws_ebs_volume.raid_array[count.index].id
   instance_id = aws_instance.instance.id

--- a/variables.tf
+++ b/variables.tf
@@ -94,4 +94,5 @@ variable "encrypt_volumes" {
 variable "region" {
   description = "The AWS region to deploy resources in"
   type        = string
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -90,3 +90,8 @@ variable "encrypt_volumes" {
   type        = bool
   default     = true
 }
+
+variable "region" {
+  description = "The AWS region to deploy resources in"
+  type        = string
+}


### PR DESCRIPTION
With the latest AWS Provider release for Terraform, a new feature called Enhanced Region Support is now available. This allows users to deploy resources across multiple regions by specifying the region argument directly within resource and data blocks, rather than maintaining separate provider configurations for each region.

This allows our configuration to be made simpler as we can rely on a single provider setup instead of having to configure multiple providers with one in each region as we have done previously.

The goal of this PR is to upgrade the Terraform version used in this module and enable users to pass a region argument, which will automatically cascade through the module’s resources.